### PR TITLE
Update rrdtool version check. 1.7 branch works.

### DIFF
--- a/libexec/NfSenRRD.pm
+++ b/libexec/NfSenRRD.pm
@@ -73,7 +73,7 @@ sub GetRRDoffset {
 	if ( $rrd_version < 1.1 ) { # it's RRD 1.0.x
 		$RRDoffset = 77;
 	}
-	if ( $rrd_version >= 1.2 && $rrd_version < 1.6 ) {
+	if ( $rrd_version >= 1.2 && $rrd_version < 1.7 ) {
 		$RRDoffset = 67;
 	}
 


### PR DESCRIPTION
Nfsen complains if the rrdtool version is higher than 1.6. 1.7 actually works, so the version check is changed to include (1.2, 1.7).

Curiously, despite being version 1.7.0, $RRDs::VERSION declares 1.699. 

